### PR TITLE
Cross GHC version compatible monoid instance

### DIFF
--- a/src/Sound/MusicW/FloatArraySpec.hs
+++ b/src/Sound/MusicW/FloatArraySpec.hs
@@ -1,4 +1,17 @@
-module Sound.MusicW.FloatArraySpec where
+{-# LANGUAGE CPP #-}
+module Sound.MusicW.FloatArraySpec (
+  FloatArraySpec(..),
+  arraySpecMap,
+  arraySpecSize,
+  listToArraySpec
+) where
+
+#if MIN_VERSION_base(4,9,0)
+import Data.Semigroup as Semi
+#endif
+#if !(MIN_VERSION_base(4,8,0))
+import Data.Monoid
+#endif
 
 data FloatArraySpec
   = EmptyArray
@@ -7,13 +20,26 @@ data FloatArraySpec
   | Repeated Int [Double] FloatArraySpec
   deriving (Show)
 
+mappendFloatArraySpec :: FloatArraySpec -> FloatArraySpec -> FloatArraySpec
+mappendFloatArraySpec EmptyArray x = x
+mappendFloatArraySpec x EmptyArray = x
+mappendFloatArraySpec (Const i x tl) y = Const i x $ mappendFloatArraySpec tl y
+mappendFloatArraySpec (Segment xs tl) y = Segment xs $ mappendFloatArraySpec tl y
+mappendFloatArraySpec (Repeated i xs tl) y = Repeated i xs $ mappendFloatArraySpec tl y
+
+#if MIN_VERSION_base(4,9,0)
+instance Semi.Semigroup FloatArraySpec where
+  (<>) = mappendFloatArraySpec
+#endif
+
 instance Monoid FloatArraySpec where
   mempty = EmptyArray
-  mappend EmptyArray x = x
-  mappend x EmptyArray = x
-  mappend (Const i x tl) y = Const i x $ mappend tl y
-  mappend (Segment xs tl) y = Segment xs $ mappend tl y
-  mappend (Repeated i xs tl) y = Repeated i xs $ mappend tl y
+#if MIN_VERSION_base(4,11,0)
+#elif MIN_VERSION_base(4,9,0)
+  mappend = (Semi.<>)
+#else
+  mappend = mappendFloatArraySpec
+#endif
 
 arraySpecMap :: (Double -> Double) -> FloatArraySpec -> FloatArraySpec
 arraySpecMap _ EmptyArray = EmptyArray


### PR DESCRIPTION
Provide a monoid instance for `FloatArraySpec` that works on older and newer ghc versions based on https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid#Writingcompatiblecode